### PR TITLE
new tpl: node--spotlight--full

### DIFF
--- a/templates/node--spotlight--full.html.twig
+++ b/templates/node--spotlight--full.html.twig
@@ -1,0 +1,116 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+     Only "getter" methods (method names starting with "get", "has", or "is")
+     and a few common methods such as "id" and "label" are available. Calling
+     other methods (such as node.delete) will result in an exception.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @ingroup templates
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{%
+  set classes = [
+    node.bundle|clean_class,
+    node.isPromoted() ? 'is-promoted',
+    node.isSticky() ? 'is-sticky',
+    not node.isPublished() ? 'is-unpublished',
+    view_mode ? view_mode|clean_class,
+    'clearfix',
+  ]
+%}
+
+{% set attributes = attributes.addClass('cwd-component') %}
+{% set has_meta, has_cats, has_tags = false, false, false %}
+{% if content.field_categories %}
+  {% set has_cats = true %}
+{% endif %}
+{% if content.field_tags %}
+  {% set has_tags = true %}
+{% endif %}
+{% if has_cats or has_tags %}
+  {% set has_meta = true %}
+{% endif %}
+
+<article{{ attributes.addClass(classes) }}>
+
+  <div{{ content_attributes.addClass('content') }}>
+    {% if has_meta == true %}
+      <div class="group-meta field-group field-group-html-element metadata-set metadata-blocks">
+        {% if has_cats == true %}
+          {% for key, item in content.field_categories['#items'] %}
+            <div class="field field-name-field-categories accent-default">
+              <span class="deco">{{ content.field_categories[key] }}</span>
+            </div>
+          {% endfor %}
+        {% endif %}
+        {% if has_tags == true %}
+          {% for key, item in content.field_tags['#items'] %}
+            <div class="field field-name-field-tags accent-default">
+              <span class="deco">{{ content.field_tags[key] }}</span>
+            </div>
+          {% endfor %}
+        {% endif %}
+      </div>
+    {% endif %}
+
+    {{ content|without('field_categories', 'field_tags') }}
+  </div>
+
+</article>


### PR DESCRIPTION
node template for spotlight--full because metadata output; goes with commit #3c5c18e in main sustainability code repo

_("full" == "default" view mode unless otherwise specified, so that's what this template targets)_